### PR TITLE
fix: lookbehind assertion with malformed regex

### DIFF
--- a/syntaxes/wit.tmLanguage.json
+++ b/syntaxes/wit.tmLanguage.json
@@ -170,7 +170,7 @@
               "include": "#extern"
             }
           ],
-          "end": "(?<=\\s*\\n)",
+          "end": "\\s*(?<=\\n)",
           "applyEndPatternLast": 1
         },
         {
@@ -193,7 +193,7 @@
               "include": "#extern"
             }
           ],
-          "end": "(?<=\\s*\\n)",
+          "end": "\\s*(?<=\\n)",
           "applyEndPatternLast": 1
         },
         {
@@ -404,7 +404,7 @@
           "include": "#types"
         }
       ],
-      "end": "(?<=\\s*\\n)",
+      "end": "\\s*(?<=\\n)",
       "applyEndPatternLast": 1
     },
     "record": {
@@ -945,7 +945,7 @@
           "include": "#function-definition"
         }
       ],
-      "end": "(?<=\\s*\\n)",
+      "end": "\\s*(?<=\\n)",
       "applyEndPatternLast": 1
     },
     "function-definition": {


### PR DESCRIPTION
This will fix the issue reported by the Linguist grammar validation:
> Invalid regex in grammar: `source.wit` (in `syntaxes/wit.tmLanguage.json`) contains a malformed regex (regex "`(?<=\s*\n)`": lookbehind assertion is not fixed length (at offset 9))