### PR TITLE
feat: add include keyword to wit grammar

### DIFF
--- a/syntaxes/wit.tmLanguage.json
+++ b/syntaxes/wit.tmLanguage.json
@@ -195,6 +195,70 @@
           "applyEndPatternLast": 1
         },
         {
+          "name": "meta.include-item.wit",
+          "comment": "Syntax for WIT like `include \"use-path\"`",
+          "begin": "\\s*\\b(include)\\s+([^\\s]+)\\s*",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.include.include-item.wit"
+            },
+            "2": {
+              "name": "meta.use-path.include-item.wit",
+              "patterns": [
+                {
+                  "include": "#use-path"
+                }
+              ]
+            }
+          },
+          "patterns": [
+            {
+              "name": "meta.with.include-item.wit",
+              "begin": "\\b(with)\\b\\s+(\\{)\\s*",
+              "beginCaptures": {
+                "1": {
+                  "name": "keyword.control.with.include-item.wit"
+                },
+                "2": {
+                  "name": "punctuation.brackets.curly.begin.wit"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#comment"
+                },
+                {
+                  "name": "meta.include-names-item.wit",
+                  "match": "\\s*([^\\s]+)\\s+(as)\\s+([^\\s\\,]+)\\s*",
+                  "captures": {
+                    "1": {
+                      "name": "variable.other.id.include-names-item.wit"
+                    },
+                    "2": {
+                      "name": "keyword.control.as.include-names-item.wit"
+                    },
+                    "3": {
+                      "name": "entity.name.type.include-names-item.wit"
+                    }
+                  }
+                },
+                {
+                  "name": "punctuation.comma.wit",
+                  "match": "\\s*(\\,)"
+                }
+              ],
+              "end": "\\s*(\\})\\s*",
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.brackets.curly.end.wit"
+                }
+              }
+            }
+          ],
+          "end": "\\s*(?<=\\n)",
+          "applyEndPatternLast": 1
+        },
+        {
           "include": "#use"
         },
         {

--- a/tests/grammar/world.wit
+++ b/tests/grammar/world.wit
@@ -6,6 +6,10 @@ default world some-world {
 //            ^^^^^^^^^^   entity.name.type.id.world-item.wit
 //                       ^ meta.world-item.wit punctuation.brackets.curly.begin.wit
 
+  include foo
+//^^^^^^^    keyword.control.include.include-item.wit
+//        ^^^    meta.use-path.include-item.wit entity.name.namespace.id.use-path.wit
+
   import filesystem: filesystem.filesystem
 //^^^^^^   keyword.control.import.import-item.wit
 //       ^^^^^^^^^^   variable.other.id.import-item.wit
@@ -50,6 +54,20 @@ world another-world {
 // <----    keyword.declaration.world.world-item.wit storage.type.wit
 //    ^^^^^^^^^^^^^    entity.name.type.id.world-item.wit
 //                  ^    meta.world-item.wit punctuation.brackets.curly.begin.wit
+
+  include bar with { a as a1, b as b1 }
+//^^^^^^^    keyword.control.include.include-item.wit
+//        ^^^    meta.use-path.include-item.wit entity.name.namespace.id.use-path.wit
+//            ^^^^    keyword.control.with.include-item.wit
+//                 ^    meta.with.include-item.wit punctuation.brackets.curly.begin.wit
+//                   ^    variable.other.id.include-names-item.wit
+//                     ^^    keyword.control.as.include-names-item.wit
+//                        ^^    entity.name.type.include-names-item.wit
+//                          ^    meta.with.include-item.wit punctuation.comma.wit
+//                            ^    variable.other.id.include-names-item.wit
+//                              ^^    keyword.control.as.include-names-item.wit
+//                                 ^^    entity.name.type.include-names-item.wit
+//                                    ^    meta.with.include-item.wit punctuation.brackets.curly.end.wit
 
   use pkg.path.{id}
 //^^^    keyword.other.use.use-item.wit


### PR DESCRIPTION
In order to support the [Union of Worlds proposal](https://github.com/WebAssembly/component-model/issues/169), we will add the `include` keyword to the WIT grammar.

Closes: https://github.com/bytecodealliance/vscode-wit/issues/14.