### PR TITLE
feat: add package keyword to wit grammar

### DIFF
--- a/syntaxes/wit.tmLanguage.json
+++ b/syntaxes/wit.tmLanguage.json
@@ -432,10 +432,6 @@
       "name": "meta.use-path.wit",
       "patterns": [
         {
-          "name": "variable.language.self.use-path.wit",
-          "match": "(?<!\\.)\\b(self|pkg)\\b"
-        },
-        {
           "name": "entity.name.namespace.id.use-path.wit",
           "match": "\\b((?<![\\-\\w])([a-z][0-9a-z]*|[A-Z][0-9A-Z]*)(([\\-])([a-z][0-9a-z]*|[A-Z][0-9A-Z]*))*)\\b"
         },

--- a/syntaxes/wit.tmLanguage.json
+++ b/syntaxes/wit.tmLanguage.json
@@ -13,6 +13,9 @@
       "include": "#comment"
     },
     {
+      "include": "#package"
+    },
+    {
       "include": "#world"
     },
     {
@@ -125,6 +128,51 @@
           "match": "\\-\\>"
         }
       ]
+    },
+    "package": {
+      "name": "meta.package-decl.wit",
+      "match": "\\s*(package)\\s+([^\\s]+)\\s*",
+      "captures": {
+        "1": {
+          "name": "storage.modifier.package-decl.wit"
+        },
+        "2": {
+          "name": "meta.id.package-decl.wit",
+          "patterns": [
+            {
+              "name": "meta.package-identifier.wit",
+              "match": "\\s*([^\\:]+)(\\:)([^\\@]+)((\\@)([^\\s]+))?",
+              "captures": {
+                "1": {
+                  "name": "entity.name.namespace.package-identifier.wit",
+                  "patterns": [
+                    {
+                      "include": "#identifier"
+                    }
+                  ]
+                },
+                "2": {
+                  "name": "keyword.operator.namespace.package-identifier.wit"
+                },
+                "3": {
+                  "name": "entity.name.type.package-identifier.wit",
+                  "patterns": [
+                    {
+                      "include": "#identifier"
+                    }
+                  ]
+                },
+                "5": {
+                  "name": "keyword.operator.version.package-identifier.wit"
+                },
+                "6": {
+                  "name": "variable.other.constant.version.package-identifier.wit"
+                }
+              }
+            }
+          ]
+        }
+      }
     },
     "world": {
       "name": "meta.world-item.wit",

--- a/tests/grammar/interface.wit
+++ b/tests/grammar/interface.wit
@@ -1,5 +1,9 @@
 // SYNTAX TEST "source.wit" "This tests interface shapes"
 
+package bytecodealliance:test-interface
+// <----    storage.modifier.package-decl.wit
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   meta.id.package-decl.wit
+
 interface some-interface {
 // <----    keyword.declaration.interface.interface-item.wit storage.type.wit
 //        ^^^^^^^^^^^^^^    entity.name.type.id.interface-item.wit

--- a/tests/grammar/interface.wit
+++ b/tests/grammar/interface.wit
@@ -7,7 +7,7 @@ interface some-interface {
 
   use self.io.level-L1.level-L2.{
 //^^^    keyword.other.use.use-item.wit
-//    ^^^^    variable.language.self.use-path.wit
+//    ^^^^    entity.name.namespace.id.use-path.wit
 //        ^    keyword.operator.namespace-separator.use-path.wit
 //         ^^    entity.name.namespace.id.use-path.wit
 //           ^    keyword.operator.namespace-separator.use-path.wit

--- a/tests/grammar/world.wit
+++ b/tests/grammar/world.wit
@@ -22,7 +22,7 @@ default world some-world {
 //^^^^^^   keyword.control.import.import-item.wit
 //       ^^^^^^   variable.other.id.import-item.wit
 //             ^   meta.import-item.wit keyword.operator.key-value.wit
-//               ^^^   variable.language.self.use-path.wit
+//               ^^^   entity.name.namespace.id.use-path.wit
 //                  ^   keyword.operator.namespace-separator.use-path.wit
 //                   ^^^^^^   entity.name.namespace.id.use-path.wit
 
@@ -71,7 +71,7 @@ world another-world {
 
   use pkg.path.{id}
 //^^^    keyword.other.use.use-item.wit
-//    ^^^    variable.language.self.use-path.wit
+//    ^^^    entity.name.namespace.id.use-path.wit
 //       ^    keyword.operator.namespace-separator.use-path.wit
 //        ^^^^    entity.name.namespace.id.use-path.wit
 //            ^    keyword.operator.namespace-separator.use-item.wit

--- a/tests/grammar/world.wit
+++ b/tests/grammar/world.wit
@@ -1,10 +1,18 @@
 // SYNTAX TEST "source.wit" "This tests world shapes"
 
+package bytecodealliance:test@1.0.0-beta.1
+// <----    storage.modifier.package-decl.wit
+//      ^^^^^^^^^^^^^^^^   entity.name.namespace.package-identifier.wit
+//                      ^   keyword.operator.namespace.package-identifier.wit
+//                       ^^^^   entity.name.type.package-identifier.wit
+//                           ^   keyword.operator.version.package-identifier.wit
+//                            ^^^^^^^^^^^^   variable.other.constant.version.package-identifier.wit
+
 default world some-world {
 // <----    storage.modifier.default.world-item.wit
 //      ^^^^^   keyword.declaration.world.world-item.wit storage.type.wit
 //            ^^^^^^^^^^   entity.name.type.id.world-item.wit
-//                       ^ meta.world-item.wit punctuation.brackets.curly.begin.wit
+//                       ^    meta.world-item.wit punctuation.brackets.curly.begin.wit
 
   include foo
 //^^^^^^^    keyword.control.include.include-item.wit


### PR DESCRIPTION
BREAKING CHANGE: The `default`, `self`, `pkg` keywords have been removed from the grammar.

Based on proposal [here](https://github.com/WebAssembly/component-model/issues/193):
- `default`, `self`, `pkg` are no longer keywords anymore
- `package <namespace>:<name>` is a new document-level syntax sitting on top of the file

Related to: https://github.com/bytecodealliance/vscode-wit/issues/15.