### PR TITLE
feat: add toplevel use keyword to wit grammar

### DIFF
--- a/syntaxes/wit.tmLanguage.json
+++ b/syntaxes/wit.tmLanguage.json
@@ -198,17 +198,20 @@
         },
         {
           "name": "meta.export-item.wit",
-          "comment": "Syntax for WIT like `export \"id\":`",
-          "begin": "\\s*\\b(export)\\b\\s+((?<![\\-\\w])([a-z][0-9a-z]*|[A-Z][0-9A-Z]*)(([\\-])([a-z][0-9a-z]*|[A-Z][0-9A-Z]*))*)\\s*(\\:)\\s*",
+          "comment": "Syntax for WIT like `export \"id\"`",
+          "begin": "\\s*\\b(export)\\b\\s+([^\\s]+)\\s*",
           "beginCaptures": {
             "1": {
               "name": "keyword.control.export.export-item.wit"
             },
             "2": {
-              "name": "variable.other.constant.id.export-item.wit"
-            },
-            "7": {
-              "name": "keyword.operator.key-value.wit"
+              "name": "meta.id.export-item.wit",
+              "patterns": [
+                {
+                  "name": "variable.other.constant.id.export-item.wit",
+                  "match": "\\b((?<![\\-\\w])([a-z][0-9a-z]*|[A-Z][0-9A-Z]*)(([\\-])([a-z][0-9a-z]*|[A-Z][0-9A-Z]*))*)\\b"
+                }
+              ]
             }
           },
           "patterns": [
@@ -221,17 +224,20 @@
         },
         {
           "name": "meta.import-item.wit",
-          "comment": "Syntax for WIT like `import \"id\":`",
-          "begin": "\\s*\\b(import)\\s+((?<![\\-\\w])([a-z][0-9a-z]*|[A-Z][0-9A-Z]*)(([\\-])([a-z][0-9a-z]*|[A-Z][0-9A-Z]*))*)\\s*(\\:)",
+          "comment": "Syntax for WIT like `import \"id\"`",
+          "begin": "\\s*\\b(import)\\s+([^\\s]+)\\s*",
           "beginCaptures": {
             "1": {
               "name": "keyword.control.import.import-item.wit"
             },
             "2": {
-              "name": "variable.other.id.import-item.wit"
-            },
-            "7": {
-              "name": "keyword.operator.key-value.wit"
+              "name": "meta.id.import-item.wit",
+              "patterns": [
+                {
+                  "name": "variable.other.id.import-item.wit",
+                  "match": "\\b((?<![\\-\\w])([a-z][0-9a-z]*|[A-Z][0-9A-Z]*)(([\\-])([a-z][0-9a-z]*|[A-Z][0-9A-Z]*))*)\\b"
+                }
+              ]
             }
           },
           "patterns": [

--- a/syntaxes/wit.tmLanguage.json
+++ b/syntaxes/wit.tmLanguage.json
@@ -16,6 +16,9 @@
       "include": "#package"
     },
     {
+      "include": "#toplevel-use"
+    },
+    {
       "include": "#world"
     },
     {
@@ -163,14 +166,50 @@
                   ]
                 },
                 "5": {
-                  "name": "keyword.operator.version.package-identifier.wit"
+                  "name": "keyword.operator.versioning.package-identifier.wit"
                 },
                 "6": {
-                  "name": "variable.other.constant.version.package-identifier.wit"
+                  "name": "constant.numeric.versioning.package-identifier.wit"
                 }
               }
             }
           ]
+        }
+      }
+    },
+    "toplevel-use": {
+      "name": "meta.toplevel-use-item.wit",
+      "match": "\\s*(use)\\s+([^\\s]+)(\\s+(as)\\s+([^\\s]+))?\\s*",
+      "captures": {
+        "1": {
+          "name": "keyword.other.use.toplevel-use-item.wit"
+        },
+        "2": {
+          "name": "meta.interface.toplevel-use-item.wit",
+          "patterns": [
+            {
+              "name": "entity.name.type.declaration.interface.toplevel-use-item.wit",
+              "match": "\\b((?<![\\-\\w])([a-z][0-9a-z]*|[A-Z][0-9A-Z]*)(([\\-])([a-z][0-9a-z]*|[A-Z][0-9A-Z]*))*)\\b"
+            },
+            {
+              "name": "meta.versioning.interface.toplevel-use-item.wit",
+              "match": "(\\@)((0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)",
+              "captures": {
+                "1": {
+                  "name": "keyword.operator.versioning.interface.toplevel-use-item.wit"
+                },
+                "2": {
+                  "name": "constant.numeric.versioning.interface.toplevel-use-item.wit"
+                }
+              }
+            }
+          ]
+        },
+        "4": {
+          "name": "keyword.control.as.toplevel-use-item.wit"
+        },
+        "5": {
+          "name": "entity.name.type.toplevel-use-item.wit"
         }
       }
     },
@@ -210,6 +249,18 @@
                 {
                   "name": "variable.other.constant.id.export-item.wit",
                   "match": "\\b((?<![\\-\\w])([a-z][0-9a-z]*|[A-Z][0-9A-Z]*)(([\\-])([a-z][0-9a-z]*|[A-Z][0-9A-Z]*))*)\\b"
+                },
+                {
+                  "name": "meta.versioning.id.export-item.wit",
+                  "match": "(\\@)((0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)",
+                  "captures": {
+                    "1": {
+                      "name": "keyword.operator.versioning.id.export-item.wit"
+                    },
+                    "2": {
+                      "name": "constant.numeric.versioning.id.export-item.wit"
+                    }
+                  }
                 }
               ]
             }
@@ -236,6 +287,18 @@
                 {
                   "name": "variable.other.id.import-item.wit",
                   "match": "\\b((?<![\\-\\w])([a-z][0-9a-z]*|[A-Z][0-9A-Z]*)(([\\-])([a-z][0-9a-z]*|[A-Z][0-9A-Z]*))*)\\b"
+                },
+                {
+                  "name": "meta.versioning.id.import-item.wit",
+                  "match": "(\\@)((0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)",
+                  "captures": {
+                    "1": {
+                      "name": "keyword.operator.versioning.id.import-item.wit"
+                    },
+                    "2": {
+                      "name": "constant.numeric.versioning.id.import-item.wit"
+                    }
+                  }
                 }
               ]
             }
@@ -488,6 +551,18 @@
         {
           "name": "entity.name.namespace.id.use-path.wit",
           "match": "\\b((?<![\\-\\w])([a-z][0-9a-z]*|[A-Z][0-9A-Z]*)(([\\-])([a-z][0-9a-z]*|[A-Z][0-9A-Z]*))*)\\b"
+        },
+        {
+          "name": "meta.versioning.id.use-path.wit",
+          "match": "(\\@)((0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)",
+          "captures": {
+            "1": {
+              "name": "keyword.operator.versioning.id.use-path.wit"
+            },
+            "2": {
+              "name": "constant.numeric.versioning.id.use-path.wit"
+            }
+          }
         },
         {
           "name": "keyword.operator.namespace-separator.use-path.wit",

--- a/tests/grammar/interface.wit
+++ b/tests/grammar/interface.wit
@@ -1,11 +1,23 @@
 // SYNTAX TEST "source.wit" "This tests interface shapes"
 
 package bytecodealliance:test-interface
-// <----    storage.modifier.package-decl.wit
+// <-------    storage.modifier.package-decl.wit
 //      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   meta.id.package-decl.wit
 
+use wasi:http/types@1.0.0 as http-types
+// <---    keyword.other.use.toplevel-use-item.wit
+//  ^^^^    entity.name.type.declaration.interface.toplevel-use-item.wit
+//      ^    meta.interface.toplevel-use-item.wit
+//       ^^^^    entity.name.type.declaration.interface.toplevel-use-item.wit
+//           ^    meta.interface.toplevel-use-item.wit
+//            ^^^^^    entity.name.type.declaration.interface.toplevel-use-item.wit
+//                 ^    meta.interface.toplevel-use-item.wit
+//                  ^^^^^    constant.numeric.versioning.interface.toplevel-use-item.wit
+//                        ^^    keyword.control.as.toplevel-use-item.wit
+//                           ^^^^^^^^^^    entity.name.type.toplevel-use-item.wit
+
 interface some-interface {
-// <----    keyword.declaration.interface.interface-item.wit storage.type.wit
+// <---------    keyword.declaration.interface.interface-item.wit storage.type.wit
 //        ^^^^^^^^^^^^^^    entity.name.type.id.interface-item.wit
 //                       ^    meta.interface-item.wit punctuation.brackets.curly.begin.wit
 
@@ -64,10 +76,10 @@ interface some-interface {
 //                                      ^    meta.enum-items.wit
 
 }
-// <----    meta.interface-item.wit punctuation.brackets.curly.end.wit
+// <-    meta.interface-item.wit punctuation.brackets.curly.end.wit
 
 interface another-interface {
-// <----    keyword.declaration.interface.interface-item.wit storage.type.wit
+// <---------    keyword.declaration.interface.interface-item.wit storage.type.wit
 //        ^^^^^^^^^^^^^^^^^    entity.name.type.id.interface-item.wit
 //                          ^    meta.interface-item.wit punctuation.brackets.curly.begin.wit
 
@@ -93,4 +105,4 @@ interface another-interface {
 //^    meta.record-item.wit punctuation.brackets.curly.end.wit
 
 }
-// <----    meta.interface-item.wit punctuation.brackets.curly.end.wit
+// <-    meta.interface-item.wit punctuation.brackets.curly.end.wit

--- a/tests/grammar/world.wit
+++ b/tests/grammar/world.wit
@@ -1,15 +1,15 @@
 // SYNTAX TEST "source.wit" "This tests world shapes"
 
 package bytecodealliance:test@1.0.0-beta.1
-// <----    storage.modifier.package-decl.wit
+// <-------    storage.modifier.package-decl.wit
 //      ^^^^^^^^^^^^^^^^   entity.name.namespace.package-identifier.wit
 //                      ^   keyword.operator.namespace.package-identifier.wit
 //                       ^^^^   entity.name.type.package-identifier.wit
-//                           ^   keyword.operator.version.package-identifier.wit
-//                            ^^^^^^^^^^^^   variable.other.constant.version.package-identifier.wit
+//                           ^   meta.package-identifier.wit keyword.operator.versioning.package-identifier.wit
+//                            ^^^^^^^^^^^^   meta.package-identifier.wit constant.numeric.versioning.package-identifier.wit
 
 default world some-world {
-// <----    storage.modifier.default.world-item.wit
+// <-------    storage.modifier.default.world-item.wit
 //      ^^^^^   keyword.declaration.world.world-item.wit storage.type.wit
 //            ^^^^^^^^^^   entity.name.type.id.world-item.wit
 //                       ^    meta.world-item.wit punctuation.brackets.curly.begin.wit
@@ -68,10 +68,10 @@ default world some-world {
 //     ^^^^^^    meta.types.result-list.wit entity.name.type.result.wit
 
 }
-// <----    meta.world-item.wit punctuation.brackets.curly.end.wit
+// <-    meta.world-item.wit punctuation.brackets.curly.end.wit
 
 world another-world {
-// <----    keyword.declaration.world.world-item.wit storage.type.wit
+// <-----    keyword.declaration.world.world-item.wit storage.type.wit
 //    ^^^^^^^^^^^^^    entity.name.type.id.world-item.wit
 //                  ^    meta.world-item.wit punctuation.brackets.curly.begin.wit
 
@@ -174,4 +174,4 @@ world another-world {
 //                         ^^    variable.other.constant.id.export-item.wit
 
 }
-// <----    meta.world-item.wit punctuation.brackets.curly.end.wit
+// <-    meta.world-item.wit punctuation.brackets.curly.end.wit

--- a/tests/grammar/world.wit
+++ b/tests/grammar/world.wit
@@ -18,10 +18,22 @@ default world some-world {
 //^^^^^^^    keyword.control.include.include-item.wit
 //        ^^^    meta.use-path.include-item.wit entity.name.namespace.id.use-path.wit
 
+  import kebab-name
+//^^^^^^   keyword.control.import.import-item.wit
+//       ^^^^^^^^^^    variable.other.id.import-item.wit
+
+  import namespace:package/id
+//^^^^^^   keyword.control.import.import-item.wit
+//       ^^^^^^^^^    variable.other.id.import-item.wit
+//                ^    meta.import-item.wit meta.id.import-item.wit
+//                 ^^^^^^^    variable.other.id.import-item.wit
+//                        ^    meta.import-item.wit meta.id.import-item.wit
+//                         ^^    variable.other.id.import-item.wit
+
   import filesystem: filesystem.filesystem
 //^^^^^^   keyword.control.import.import-item.wit
 //       ^^^^^^^^^^   variable.other.id.import-item.wit
-//                 ^   meta.import-item.wit keyword.operator.key-value.wit
+//                 ^   meta.import-item.wit meta.id.import-item.wit
 //                   ^^^^^^^^^^   entity.name.namespace.id.use-path.wit
 //                             ^   keyword.operator.namespace-separator.use-path.wit
 //                              ^^^^^^^^^^   entity.name.namespace.id.use-path.wit
@@ -29,7 +41,7 @@ default world some-world {
   import random: pkg.random
 //^^^^^^   keyword.control.import.import-item.wit
 //       ^^^^^^   variable.other.id.import-item.wit
-//             ^   meta.import-item.wit keyword.operator.key-value.wit
+//             ^   meta.import-item.wit meta.id.import-item.wit
 //               ^^^   entity.name.namespace.id.use-path.wit
 //                  ^   keyword.operator.namespace-separator.use-path.wit
 //                   ^^^^^^   entity.name.namespace.id.use-path.wit
@@ -37,7 +49,7 @@ default world some-world {
   export main: func(
 //^^^^^^   keyword.control.export.export-item.wit
 //       ^^^^   variable.other.constant.id.export-item.wit
-//           ^   meta.export-item.wit keyword.operator.key-value.wit
+//           ^   meta.export-item.wit meta.id.export-item.wit
 //             ^^^^   keyword.other.func.func-type.wit
 //                 ^   meta.function.wit punctuation.brackets.round.begin.wit
 
@@ -144,10 +156,22 @@ world another-world {
   export hello: func()
 //^^^^^^   keyword.control.export.export-item.wit
 //       ^^^^^    variable.other.constant.id.export-item.wit
-//            ^    meta.export-item.wit keyword.operator.key-value.wit
+//            ^    meta.export-item.wit meta.id.export-item.wit
 //              ^^^^    keyword.other.func.func-type.wit
 //                  ^    meta.function.wit punctuation.brackets.round.begin.wit
 //                   ^    meta.function.wit punctuation.brackets.round.end.wit
+
+  export kebab-name
+//^^^^^^   keyword.control.export.export-item.wit
+//       ^^^^^^^^^^    variable.other.constant.id.export-item.wit
+
+  export namespace:package/id
+//^^^^^^   keyword.control.export.export-item.wit
+//       ^^^^^^^^^    variable.other.constant.id.export-item.wit
+//                ^    meta.export-item.wit meta.id.export-item.wit
+//                 ^^^^^^^    variable.other.constant.id.export-item.wit
+//                        ^    meta.export-item.wit meta.id.export-item.wit
+//                         ^^    variable.other.constant.id.export-item.wit
 
 }
 // <----    meta.world-item.wit punctuation.brackets.curly.end.wit


### PR DESCRIPTION
Based on proposal [here](https://github.com/WebAssembly/component-model/issues/193):
- `use` becomes a document-level syntax (in contrast to that within worlds and interfaces)
- `import <package name>` and `export <package name>`

Related to: https://github.com/bytecodealliance/vscode-wit/issues/15.