### PR TITLE
fix: comments on type aliases are now recognized as comments

### DIFF
--- a/syntaxes/wit.tmLanguage.json
+++ b/syntaxes/wit.tmLanguage.json
@@ -721,6 +721,9 @@
           "include": "#types"
         },
         {
+          "include": "#comment"
+        },
+        {
           "include": "#whitespace"
         }
       ],

--- a/tests/grammar/integration/issue573.wit
+++ b/tests/grammar/integration/issue573.wit
@@ -34,9 +34,9 @@ interface types-interface {
   // type aliases are allowed to primitive types and additionally here are some
   // examples of other types
   type t1 = u32
-  type t2 = tuple<u32, u64>
+  type t2 = tuple<u32, u64> // tuple
   type t3 = string
-  type t4 = option<u32>
+  type t4 = option<u32> // option
   /// no "ok" type
   type t5 = result<_, errno>            // no "ok" type
   type t6 = result<string>              // no "err" type

--- a/tests/grammar/integration/issue573.wit.snap
+++ b/tests/grammar/integration/issue573.wit.snap
@@ -161,7 +161,7 @@
 #          ^ source.wit meta.interface-item.wit meta.type-item.wit punctuation.equal.wit
 #           ^ source.wit meta.interface-item.wit meta.type-item.wit meta.whitespace.wit
 #            ^^^ source.wit meta.interface-item.wit meta.type-item.wit entity.name.type.numeric.wit
->  type t2 = tuple<u32, u64>
+>  type t2 = tuple<u32, u64> // tuple
 #^^ source.wit meta.interface-item.wit meta.whitespace.wit
 #  ^^^^ source.wit meta.interface-item.wit meta.type-item.wit keyword.declaration.type.type-item.wit storage.type.wit
 #      ^ source.wit meta.interface-item.wit meta.type-item.wit
@@ -176,6 +176,7 @@
 #                      ^ source.wit meta.interface-item.wit meta.type-item.wit meta.tuple.ty.wit meta.whitespace.wit
 #                       ^^^ source.wit meta.interface-item.wit meta.type-item.wit meta.tuple.ty.wit entity.name.type.numeric.wit
 #                          ^ source.wit meta.interface-item.wit meta.type-item.wit meta.tuple.ty.wit punctuation.brackets.angle.end.wit
+#                           ^^^^^^^^^ source.wit meta.interface-item.wit meta.type-item.wit comment.line.double-slash.wit
 >  type t3 = string
 #^^ source.wit meta.interface-item.wit meta.whitespace.wit
 #  ^^^^ source.wit meta.interface-item.wit meta.type-item.wit keyword.declaration.type.type-item.wit storage.type.wit
@@ -185,7 +186,7 @@
 #          ^ source.wit meta.interface-item.wit meta.type-item.wit punctuation.equal.wit
 #           ^ source.wit meta.interface-item.wit meta.type-item.wit meta.whitespace.wit
 #            ^^^^^^ source.wit meta.interface-item.wit meta.type-item.wit entity.name.type.string.wit
->  type t4 = option<u32>
+>  type t4 = option<u32> // option
 #^^ source.wit meta.interface-item.wit meta.whitespace.wit
 #  ^^^^ source.wit meta.interface-item.wit meta.type-item.wit keyword.declaration.type.type-item.wit storage.type.wit
 #      ^ source.wit meta.interface-item.wit meta.type-item.wit
@@ -197,6 +198,7 @@
 #                  ^ source.wit meta.interface-item.wit meta.type-item.wit meta.option.ty.wit punctuation.brackets.angle.begin.wit
 #                   ^^^ source.wit meta.interface-item.wit meta.type-item.wit meta.option.ty.wit entity.name.type.numeric.wit
 #                      ^ source.wit meta.interface-item.wit meta.type-item.wit meta.option.ty.wit punctuation.brackets.angle.end.wit
+#                       ^^^^^^^^^^ source.wit meta.interface-item.wit meta.type-item.wit comment.line.double-slash.wit
 >  /// no "ok" type
 #^^^^^ source.wit meta.interface-item.wit comment.line.documentation.wit
 #     ^^^^^^^^^^^^^ source.wit meta.interface-item.wit comment.line.documentation.wit

--- a/tests/grammar/unit/interface.wit
+++ b/tests/grammar/unit/interface.wit
@@ -83,11 +83,12 @@ interface another-interface {
 //        ^^^^^^^^^^^^^^^^^    entity.name.type.id.interface-item.wit
 //                          ^    meta.interface-item.wit punctuation.brackets.curly.begin.wit
 
-  type my-type = string
+  type my-type = string // comment
 //^^^^    keyword.declaration.type.type-item.wit
 //     ^^^^^^^    entity.name.type.id.type-item.wit
 //             ^    meta.type-item.wit punctuation.equal.wit
 //               ^^^^^^    entity.name.type.string.wit
+//                      ^^^^^^^^^^    comment.line.double-slash.wit
 
   record my-record {
 //^^^^^^    keyword.declaration.record.record-item.wit


### PR DESCRIPTION
fix https://github.com/bytecodealliance/vscode-wit/issues/38

before
<img width="493" alt="Screenshot 2025-02-21 at 15 59 49" src="https://github.com/user-attachments/assets/dd8e7cae-2138-414a-8d8c-d41cab61adbf" />


after
<img width="507" alt="Screenshot 2025-02-21 at 15 58 38" src="https://github.com/user-attachments/assets/51277a5b-0b4f-49e0-bb32-2ed47a29e3b1" />



